### PR TITLE
feat: add platformId to payload and refactor sample metadata handling

### DIFF
--- a/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
@@ -636,6 +636,8 @@ class HealthManager {
             }
         }
 
+        payload.put("platformId", metadata.id)
+
         return payload
     }
 
@@ -912,9 +914,11 @@ class HealthManager {
             }
         }
         
+        payload.put("platformId", session.metadata.id)
+
         // Note: customMetadata is not available on Metadata in Health Connect
         // Metadata only contains dataOrigin, device, and lastModifiedTime
-        
+
         return payload
     }
 

--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -898,9 +898,7 @@ final class Health {
                         payload["sleepState"] = sleepState
                     }
 
-                    let source = sample.sourceRevision.source
-                    payload["sourceName"] = source.name
-                    payload["sourceId"] = source.bundleIdentifier
+                    self.addSampleMetadata(sample, to: &payload)
 
                     return payload
                 }
@@ -910,7 +908,7 @@ final class Health {
             healthStore.execute(query)
             return
         }
-        
+
         // Handle mindfulness as a category sample
         if dataType == .mindfulness {
             let query = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: queryLimit, sortDescriptors: [sortDescriptor]) { [weak self] _, samples, error in
@@ -937,9 +935,7 @@ final class Health {
                         "endDate": self.isoFormatter.string(from: sample.endDate)
                     ]
 
-                    let source = sample.sourceRevision.source
-                    payload["sourceName"] = source.name
-                    payload["sourceId"] = source.bundleIdentifier
+                    self.addSampleMetadata(sample, to: &payload)
 
                     return payload
                 }
@@ -949,7 +945,7 @@ final class Health {
             healthStore.execute(query)
             return
         }
-        
+
         // Handle blood pressure as a correlation sample
         if dataType == .bloodPressure {
             let query = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: queryLimit, sortDescriptors: [sortDescriptor]) { [weak self] _, samples, error in
@@ -986,9 +982,7 @@ final class Health {
                         "diastolic": diastolicValue
                     ]
 
-                    let source = correlation.sourceRevision.source
-                    payload["sourceName"] = source.name
-                    payload["sourceId"] = source.bundleIdentifier
+                    self.addSampleMetadata(correlation, to: &payload)
 
                     return payload
                 }
@@ -1023,9 +1017,7 @@ final class Health {
                     "endDate": self.isoFormatter.string(from: sample.endDate)
                 ]
 
-                let source = sample.sourceRevision.source
-                payload["sourceName"] = source.name
-                payload["sourceId"] = source.bundleIdentifier
+                self.addSampleMetadata(sample, to: &payload)
 
                 return payload
             }
@@ -1036,6 +1028,13 @@ final class Health {
         healthStore.execute(query)
     }
     
+    private func addSampleMetadata(_ sample: HKSample, to payload: inout [String: Any]) {
+        let source = sample.sourceRevision.source
+        payload["sourceName"] = source.name
+        payload["sourceId"] = source.bundleIdentifier
+        payload["platformId"] = sample.uuid.uuidString
+    }
+
     private func sleepStateFromValue(_ value: Int) -> String? {
         switch value {
         case HKCategoryValueSleepAnalysis.inBed.rawValue:
@@ -1584,10 +1583,8 @@ final class Health {
             payload["totalDistance"] = distanceInMeters
         }
 
-        // Add source information
-        let source = workout.sourceRevision.source
-        payload["sourceName"] = source.name
-        payload["sourceId"] = source.bundleIdentifier
+        // Add source information and platform ID
+        addSampleMetadata(workout, to: &payload)
 
         // Add metadata if available
         if let metadata = workout.metadata, !metadata.isEmpty {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -81,6 +81,8 @@ export interface HealthSample {
   endDate: string;
   sourceName?: string;
   sourceId?: string;
+  /** Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android). */
+  platformId?: string;
   /** For sleep data, indicates the sleep state (e.g., 'asleep', 'awake', 'rem', 'deep', 'light'). */
   sleepState?: SleepState;
   /** For blood pressure data, the systolic value in mmHg. */
@@ -264,6 +266,8 @@ export interface Workout {
   sourceName?: string;
   /** Source bundle identifier. */
   sourceId?: string;
+  /** Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android). */
+  platformId?: string;
   /** Additional metadata (if available). */
   metadata?: Record<string, string>;
 }


### PR DESCRIPTION
This pull request introduces a new `platformId` field to both iOS and Android health data payloads, providing a platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android) for each health sample and workout. The implementation refactors how source metadata is added on iOS by centralizing it into a helper method, improving code maintainability and consistency.

**Platform identifier support:**

* Added a `platformId` property to the `HealthSample` and `Workout` interfaces in `src/definitions.ts`, with documentation explaining its purpose. [[1]](diffhunk://#diff-f1f3c6677661c21128a30f64358c6615c6801043e1cbfcc904302422a17b3246R84-R85) [[2]](diffhunk://#diff-f1f3c6677661c21128a30f64358c6615c6801043e1cbfcc904302422a17b3246R269-R270)
* On Android, updated the `HealthManager` class to include the Health Connect metadata ID as `platformId` in the payload for samples and sessions. [[1]](diffhunk://#diff-38e04b74af231f2d6014f915d31945f97230e1f8f27e171ae749a424b3955423R639-R640) [[2]](diffhunk://#diff-38e04b74af231f2d6014f915d31945f97230e1f8f27e171ae749a424b3955423R917-R918)
* On iOS, refactored the `Health` class to add the HealthKit sample UUID as `platformId` in all relevant payloads via a new `addSampleMetadata` helper method. [[1]](diffhunk://#diff-bd1c15061afc0571850bcc6b399eec96f8c4c50bc3b1fcd35ffe65d36ca79bcbL901-R901) [[2]](diffhunk://#diff-bd1c15061afc0571850bcc6b399eec96f8c4c50bc3b1fcd35ffe65d36ca79bcbL940-R938) [[3]](diffhunk://#diff-bd1c15061afc0571850bcc6b399eec96f8c4c50bc3b1fcd35ffe65d36ca79bcbL989-R985) [[4]](diffhunk://#diff-bd1c15061afc0571850bcc6b399eec96f8c4c50bc3b1fcd35ffe65d36ca79bcbL1026-R1020) [[5]](diffhunk://#diff-bd1c15061afc0571850bcc6b399eec96f8c4c50bc3b1fcd35ffe65d36ca79bcbR1031-R1037) [[6]](diffhunk://#diff-bd1c15061afc0571850bcc6b399eec96f8c4c50bc3b1fcd35ffe65d36ca79bcbL1587-R1587)

**Code maintainability improvements (iOS):**

* Centralized the logic for adding source metadata and the new `platformId` into a single helper method, reducing code duplication and improving readability in the `Health` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific identifier field to health samples and workout data across Android, iOS, and API definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->