### PR TITLE
feat: add VO2 max health data type

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ const { samples: avgHR } = await Health.queryAggregated({
 });
 ```
 
-**Note:** Aggregated queries are not supported for sleep, respiratory rate, oxygen saturation, and heart rate variability data types. These are instantaneous measurements and should use `readSamples()` instead. Aggregation is supported for: steps, distance, calories, heart rate, weight, and resting heart rate.
+**Note:** Aggregated queries are not supported for sleep, respiratory rate, oxygen saturation, heart rate variability, and VO2 max data types. These measurements should use `readSamples()`, not `queryAggregated()`. Aggregation is supported for: steps, distance, calories, heart rate, weight, and resting heart rate.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ await Health.saveSample({
 | `oxygenSaturation`      | `percent`     | Blood oxygen saturation (SpO2)                           |
 | `restingHeartRate`      | `bpm`         | Resting heart rate                                       |
 | `heartRateVariability`  | `millisecond` | Heart rate variability (HRV)                             |
+| `vo2Max`                | `mL/min/kg`   | VO2 max (Android Health Connect)                         |
 | `bloodPressure`         | `mmHg`        | Blood pressure (requires systolic/diastolic values)      |
 | `bloodGlucose`          | `mg/dL`       | Blood glucose level                                      |
 | `bodyTemperature`       | `celsius`     | Body temperature                                         |
@@ -541,19 +542,20 @@ Supported on iOS (HealthKit) and Android (Health Connect).
 
 #### HealthSample
 
-| Prop             | Type                                                      | Description                                                                                         |
-| ---------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **`dataType`**   | <code><a href="#healthdatatype">HealthDataType</a></code> |                                                                                                     |
-| **`value`**      | <code>number</code>                                       |                                                                                                     |
-| **`unit`**       | <code><a href="#healthunit">HealthUnit</a></code>         |                                                                                                     |
-| **`startDate`**  | <code>string</code>                                       |                                                                                                     |
-| **`endDate`**    | <code>string</code>                                       |                                                                                                     |
-| **`sourceName`** | <code>string</code>                                       |                                                                                                     |
-| **`sourceId`**   | <code>string</code>                                       |                                                                                                     |
-| **`platformId`** | <code>string</code>                                       | Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android). |
-| **`sleepState`** | <code><a href="#sleepstate">SleepState</a></code>         | For sleep data, indicates the sleep state (e.g., 'asleep', 'awake', 'rem', 'deep', 'light').        |
-| **`systolic`**   | <code>number</code>                                       | For blood pressure data, the systolic value in mmHg.                                                |
-| **`diastolic`**  | <code>number</code>                                       | For blood pressure data, the diastolic value in mmHg.                                               |
+| Prop                    | Type                                                      | Description                                                                                         |
+| ----------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **`dataType`**          | <code><a href="#healthdatatype">HealthDataType</a></code> |                                                                                                     |
+| **`value`**             | <code>number</code>                                       |                                                                                                     |
+| **`unit`**              | <code><a href="#healthunit">HealthUnit</a></code>         |                                                                                                     |
+| **`startDate`**         | <code>string</code>                                       |                                                                                                     |
+| **`endDate`**           | <code>string</code>                                       |                                                                                                     |
+| **`sourceName`**        | <code>string</code>                                       |                                                                                                     |
+| **`sourceId`**          | <code>string</code>                                       |                                                                                                     |
+| **`platformId`**        | <code>string</code>                                       | Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android). |
+| **`sleepState`**        | <code><a href="#sleepstate">SleepState</a></code>         | For sleep data, indicates the sleep state (e.g., 'asleep', 'awake', 'rem', 'deep', 'light').        |
+| **`systolic`**          | <code>number</code>                                       | For blood pressure data, the systolic value in mmHg.                                                |
+| **`diastolic`**         | <code>number</code>                                       | For blood pressure data, the diastolic value in mmHg.                                               |
+| **`measurementMethod`** | <code>number</code>                                       | For VO2 max data on Android, Health Connect's measurement method enum value.                        |
 
 
 #### QueryOptions
@@ -650,12 +652,12 @@ Supported on iOS (HealthKit) and Android (Health Connect).
 
 #### HealthDataType
 
-<code>'steps' | 'distance' | 'calories' | 'heartRate' | 'weight' | 'sleep' | 'respiratoryRate' | 'oxygenSaturation' | 'restingHeartRate' | 'heartRateVariability' | 'bloodPressure' | 'bloodGlucose' | 'bodyTemperature' | 'height' | 'flightsClimbed' | 'exerciseTime' | 'distanceCycling' | 'bodyFat' | 'basalBodyTemperature' | 'basalCalories' | 'totalCalories' | 'mindfulness' | 'workouts'</code>
+<code>'steps' | 'distance' | 'calories' | 'heartRate' | 'weight' | 'sleep' | 'respiratoryRate' | 'oxygenSaturation' | 'restingHeartRate' | 'heartRateVariability' | 'vo2Max' | 'bloodPressure' | 'bloodGlucose' | 'bodyTemperature' | 'height' | 'flightsClimbed' | 'exerciseTime' | 'distanceCycling' | 'bodyFat' | 'basalBodyTemperature' | 'basalCalories' | 'totalCalories' | 'mindfulness' | 'workouts'</code>
 
 
 #### HealthUnit
 
-<code>'count' | 'meter' | 'kilocalorie' | 'bpm' | 'kilogram' | 'minute' | 'percent' | 'millisecond' | 'mmHg' | 'mg/dL' | 'celsius' | 'fahrenheit' | 'centimeter'</code>
+<code>'count' | 'meter' | 'kilocalorie' | 'bpm' | 'kilogram' | 'minute' | 'percent' | 'millisecond' | 'mL/min/kg' | 'mmHg' | 'mg/dL' | 'celsius' | 'fahrenheit' | 'centimeter'</code>
 
 
 #### SleepState

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.health.WRITE_RESTING_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE_VARIABILITY" />
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
+    <uses-permission android:name="android.permission.health.READ_VO2_MAX" />
+    <uses-permission android:name="android.permission.health.WRITE_VO2_MAX" />
     <uses-permission android:name="android.permission.health.READ_BLOOD_PRESSURE" />
     <uses-permission android:name="android.permission.health.WRITE_BLOOD_PRESSURE" />
     <uses-permission android:name="android.permission.health.READ_BLOOD_GLUCOSE" />

--- a/android/src/main/java/app/capgo/plugin/health/HealthDataType.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthDataType.kt
@@ -22,6 +22,7 @@ import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.WeightRecord
 import kotlin.reflect.KClass
 
@@ -41,6 +42,7 @@ enum class HealthDataType(
     OXYGEN_SATURATION("oxygenSaturation", OxygenSaturationRecord::class, "percent"),
     RESTING_HEART_RATE("restingHeartRate", RestingHeartRateRecord::class, "bpm"),
     HEART_RATE_VARIABILITY("heartRateVariability", HeartRateVariabilityRmssdRecord::class, "millisecond"),
+    VO2_MAX("vo2Max", Vo2MaxRecord::class, "mL/min/kg"),
     BLOOD_PRESSURE("bloodPressure", BloodPressureRecord::class, "mmHg"),
     BLOOD_GLUCOSE("bloodGlucose", BloodGlucoseRecord::class, "mg/dL"),
     BODY_TEMPERATURE("bodyTemperature", BodyTemperatureRecord::class, "celsius"),

--- a/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
@@ -25,6 +25,7 @@ import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.request.ReadRecordsRequest
@@ -221,6 +222,17 @@ class HealthManager {
                     record.heartRateVariabilityMillis,
                     record.metadata
                 )
+                samples.add(record.time to payload)
+            }
+            HealthDataType.VO2_MAX -> readRecords(client, Vo2MaxRecord::class, startTime, endTime, limit) { record ->
+                val payload = createSamplePayload(
+                    dataType,
+                    record.time,
+                    record.time,
+                    record.vo2MillilitersPerMinuteKilogram,
+                    record.metadata
+                )
+                payload.put("measurementMethod", record.measurementMethod)
                 samples.add(record.time to payload)
             }
             HealthDataType.BLOOD_PRESSURE -> readRecords(client, BloodPressureRecord::class, startTime, endTime, limit) { record ->
@@ -489,6 +501,15 @@ class HealthManager {
                 )
                 client.insertRecords(listOf(record))
             }
+            HealthDataType.VO2_MAX -> {
+                val record = Vo2MaxRecord(
+                    time = startTime,
+                    zoneOffset = zoneOffset(startTime),
+                    metadata = recordMetadata,
+                    vo2MillilitersPerMinuteKilogram = value
+                )
+                client.insertRecords(listOf(record))
+            }
             HealthDataType.BLOOD_PRESSURE -> {
                 if (systolic == null || diastolic == null) {
                     throw IllegalArgumentException("Blood pressure requires both systolic and diastolic values")
@@ -666,7 +687,8 @@ class HealthManager {
         // These data types should use readSamples instead
         if (dataType == HealthDataType.RESPIRATORY_RATE || 
             dataType == HealthDataType.OXYGEN_SATURATION || 
-            dataType == HealthDataType.HEART_RATE_VARIABILITY) {
+            dataType == HealthDataType.HEART_RATE_VARIABILITY ||
+            dataType == HealthDataType.VO2_MAX) {
             throw IllegalArgumentException("Aggregated queries are not supported for ${dataType.identifier}. Use readSamples instead.")
         }
 

--- a/example-app/android/app/build.gradle
+++ b/example-app/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles = getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,6 +9,7 @@ export type HealthDataType =
   | 'oxygenSaturation'
   | 'restingHeartRate'
   | 'heartRateVariability'
+  | 'vo2Max'
   | 'bloodPressure'
   | 'bloodGlucose'
   | 'bodyTemperature'
@@ -32,6 +33,7 @@ export type HealthUnit =
   | 'minute'
   | 'percent'
   | 'millisecond'
+  | 'mL/min/kg'
   | 'mmHg'
   | 'mg/dL'
   | 'celsius'
@@ -90,6 +92,8 @@ export interface HealthSample {
   systolic?: number;
   /** For blood pressure data, the diastolic value in mmHg. */
   diastolic?: number;
+  /** For VO2 max data on Android, Health Connect's measurement method enum value. */
+  measurementMethod?: number;
 }
 
 export interface ReadSamplesResult {


### PR DESCRIPTION
## What
- Add `vo2Max` to the public health data type union and generated docs.
- Map `vo2Max` to Android Health Connect `Vo2MaxRecord` for authorization, reads, and writes.
- Return Health Connect VO2 max measurement method values with read samples.
- Make the packed example verification script work when native platforms already exist, and fix the example Android ProGuard Gradle syntax.

## Why
- Fixes #51 so apps can request and read VO2 max data written to Health Connect by devices such as Ultrahuman.
- The CI packed-example workflow added on `main` needed these small fixes to pass for this PR.

## How
- Added Android `Vo2MaxRecord` imports, enum mapping, manifest permissions, read/write handlers, and aggregation rejection like other instantaneous measurements.
- Regenerated README API docs from `src/definitions.ts`.
- Made packed example platform creation idempotent.

## Testing
- `bun run build`
- `bun run check:wiring`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME=~/Library/Android/sdk ANDROID_SDK_ROOT=~/Library/Android/sdk cd android && ./gradlew clean build test`
- `bun run verify:ios`
- `bash ./.github/scripts/verify-packed-example.sh web`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME=~/Library/Android/sdk ANDROID_SDK_ROOT=~/Library/Android/sdk bash ./.github/scripts/verify-packed-example.sh android`
- `bash ./.github/scripts/verify-packed-example.sh ios`

## Not Tested
- Reading real VO2 max samples from a physical Android device with Health Connect data. Android compile and packed-example verification passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VO2 Max health data support (read/save) with unit mL/min/kg and Android measurementMethod metadata.
  * Updated permission requests to include VO2 Max on Android.

* **Documentation**
  * Docs updated to include vo2Max, mL/min/kg, measurementMethod, and guidance to use readSamples() for VO2 Max (not aggregated queries).

* **Chores**
  * Improved example script to conditionally add platforms before syncing/building.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-health/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->