### PR TITLE
[codex] fix Health Connect settings intent on Android 14+

### DIFF
--- a/android/src/main/java/app/capgo/plugin/health/HealthPlugin.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthPlugin.kt
@@ -330,7 +330,7 @@ class HealthPlugin : Plugin() {
     @PluginMethod
     fun openHealthConnectSettings(call: PluginCall) {
         try {
-            val intent = Intent(HEALTH_CONNECT_SETTINGS_ACTION)
+            val intent = Intent(HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             context.startActivity(intent)
             call.resolve()
@@ -440,6 +440,5 @@ class HealthPlugin : Plugin() {
     companion object {
         private const val DEFAULT_LIMIT = 100
         private val DEFAULT_PAST_DURATION: Duration = Duration.ofDays(1)
-        private const val HEALTH_CONNECT_SETTINGS_ACTION = "androidx.health.ACTION_HEALTH_CONNECT_SETTINGS"
     }
 }


### PR DESCRIPTION
## What
- Use `HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS` when opening Health Connect settings on Android.
- Remove the hard-coded legacy settings action constant.

## Why
- Fixes #53. Android 14+ requires the version-aware Jetpack action; the hard-coded action can fail with `ActivityNotFoundException`.

## How
- Reused the existing `HealthConnectClient` import and delegated action selection to the Health Connect SDK.

## Testing
- `bun install --frozen-lockfile`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/martindonadieu/Library/Android/sdk bun run verify:android`
- `bun run verify:ios`
- Web build via Bun-local steps: `bun run clean`, `bun run docgen`, `bun node_modules/.bin/tsc`, `bun node_modules/.bin/rollup -c rollup.config.mjs`
- `bun run prettier -- --check`
- `bun run eslint` (passes with existing warnings in `src/web.ts`)

## Not Tested
- Manual Android 14+ device/emulator launch of the Health Connect settings screen was not run locally.
- `bun run swiftlint -- lint` still fails on existing iOS lint violations unrelated to this Android change.

Prepared with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Health Connect settings integration by using the official API constant for better compatibility and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-health/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->