### PR TITLE
fix: ignore non-finite health sample values

### DIFF
--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -972,7 +972,8 @@ final class Health {
                     
                     let systolicValue = systolicSample.quantity.doubleValue(for: HKUnit.millimeterOfMercury())
                     let diastolicValue = diastolicSample.quantity.doubleValue(for: HKUnit.millimeterOfMercury())
-                    guard diastolicValue.isFinite,
+                    guard systolicValue.isFinite,
+                          diastolicValue.isFinite,
                           var payload = self.readSamplePayload(
                               dataType: dataType,
                               value: systolicValue,

--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -881,17 +881,17 @@ final class Health {
                     return
                 }
 
-                let results = categorySamples.map { sample -> [String: Any] in
+                let results = categorySamples.compactMap { sample -> [String: Any]? in
                     let sleepValue = sample.value
                     let durationMinutes = sample.endDate.timeIntervalSince(sample.startDate) / 60.0
-                    
-                    var payload: [String: Any] = [
-                        "dataType": dataType.rawValue,
-                        "value": durationMinutes,
-                        "unit": dataType.unitIdentifier,
-                        "startDate": self.isoFormatter.string(from: sample.startDate),
-                        "endDate": self.isoFormatter.string(from: sample.endDate)
-                    ]
+                    guard var payload = self.readSamplePayload(
+                        dataType: dataType,
+                        value: durationMinutes,
+                        startDate: sample.startDate,
+                        endDate: sample.endDate
+                    ) else {
+                        return nil
+                    }
                     
                     // Map HKCategoryValueSleepAnalysis to sleep state
                     let sleepState = self.sleepStateFromValue(sleepValue)
@@ -925,16 +925,16 @@ final class Health {
                     return
                 }
 
-                let results = categorySamples.map { sample -> [String: Any] in
+                let results = categorySamples.compactMap { sample -> [String: Any]? in
                     let durationMinutes = sample.endDate.timeIntervalSince(sample.startDate) / 60.0
-                    
-                    var payload: [String: Any] = [
-                        "dataType": dataType.rawValue,
-                        "value": durationMinutes,
-                        "unit": dataType.unitIdentifier,
-                        "startDate": self.isoFormatter.string(from: sample.startDate),
-                        "endDate": self.isoFormatter.string(from: sample.endDate)
-                    ]
+                    guard var payload = self.readSamplePayload(
+                        dataType: dataType,
+                        value: durationMinutes,
+                        startDate: sample.startDate,
+                        endDate: sample.endDate
+                    ) else {
+                        return nil
+                    }
 
                     self.addSampleMetadata(sample, to: &payload)
 
@@ -972,16 +972,18 @@ final class Health {
                     
                     let systolicValue = systolicSample.quantity.doubleValue(for: HKUnit.millimeterOfMercury())
                     let diastolicValue = diastolicSample.quantity.doubleValue(for: HKUnit.millimeterOfMercury())
-                    
-                    var payload: [String: Any] = [
-                        "dataType": dataType.rawValue,
-                        "value": systolicValue,
-                        "unit": dataType.unitIdentifier,
-                        "startDate": self.isoFormatter.string(from: correlation.startDate),
-                        "endDate": self.isoFormatter.string(from: correlation.endDate),
-                        "systolic": systolicValue,
-                        "diastolic": diastolicValue
-                    ]
+                    guard diastolicValue.isFinite,
+                          var payload = self.readSamplePayload(
+                              dataType: dataType,
+                              value: systolicValue,
+                              startDate: correlation.startDate,
+                              endDate: correlation.endDate
+                          ) else {
+                        return nil
+                    }
+
+                    payload["systolic"] = systolicValue
+                    payload["diastolic"] = diastolicValue
 
                     self.addSampleMetadata(correlation, to: &payload)
 
@@ -1008,15 +1010,16 @@ final class Health {
                 return
             }
 
-            let results = quantitySamples.map { sample -> [String: Any] in
+            let results = quantitySamples.compactMap { sample -> [String: Any]? in
                 let value = sample.quantity.doubleValue(for: dataType.defaultUnit)
-                var payload: [String: Any] = [
-                    "dataType": dataType.rawValue,
-                    "value": value,
-                    "unit": dataType.unitIdentifier,
-                    "startDate": self.isoFormatter.string(from: sample.startDate),
-                    "endDate": self.isoFormatter.string(from: sample.endDate)
-                ]
+                guard var payload = self.readSamplePayload(
+                    dataType: dataType,
+                    value: value,
+                    startDate: sample.startDate,
+                    endDate: sample.endDate
+                ) else {
+                    return nil
+                }
 
                 self.addSampleMetadata(sample, to: &payload)
 
@@ -1027,6 +1030,20 @@ final class Health {
         }
 
         healthStore.execute(query)
+    }
+
+    func readSamplePayload(dataType: HealthDataType, value: Double, startDate: Date, endDate: Date) -> [String: Any]? {
+        guard value.isFinite else {
+            return nil
+        }
+
+        return [
+            "dataType": dataType.rawValue,
+            "value": value,
+            "unit": dataType.unitIdentifier,
+            "startDate": isoFormatter.string(from: startDate),
+            "endDate": isoFormatter.string(from: endDate)
+        ]
     }
     
     private func addSampleMetadata(_ sample: HKSample, to payload: inout [String: Any]) {

--- a/ios/Tests/HealthPluginTests/HealthPluginTests.swift
+++ b/ios/Tests/HealthPluginTests/HealthPluginTests.swift
@@ -2,14 +2,48 @@ import XCTest
 @testable import HealthPlugin
 
 class HealthTests: XCTestCase {
-    func testEcho() {
-        // This is an example of a functional test case for a plugin.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-
+    func testReadSamplePayloadIncludesFiniteValue() {
         let implementation = Health()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
+        let startDate = Date(timeIntervalSince1970: 0)
+        let endDate = Date(timeIntervalSince1970: 60)
 
-        XCTAssertEqual(value, result)
+        let payload = implementation.readSamplePayload(
+            dataType: .oxygenSaturation,
+            value: 0.96,
+            startDate: startDate,
+            endDate: endDate
+        )
+
+        XCTAssertEqual(payload?["dataType"] as? String, "oxygenSaturation")
+        XCTAssertEqual(payload?["value"] as? Double, 0.96)
+        XCTAssertEqual(payload?["unit"] as? String, "percent")
+    }
+
+    func testReadSamplePayloadRejectsNaNValue() {
+        let implementation = Health()
+        let startDate = Date(timeIntervalSince1970: 0)
+
+        let payload = implementation.readSamplePayload(
+            dataType: .oxygenSaturation,
+            value: .nan,
+            startDate: startDate,
+            endDate: startDate
+        )
+
+        XCTAssertNil(payload)
+    }
+
+    func testReadSamplePayloadRejectsInfiniteValue() {
+        let implementation = Health()
+        let startDate = Date(timeIntervalSince1970: 0)
+
+        let payload = implementation.readSamplePayload(
+            dataType: .bloodGlucose,
+            value: .infinity,
+            startDate: startDate,
+            endDate: startDate
+        )
+
+        XCTAssertNil(payload)
     }
 }

--- a/ios/Tests/HealthPluginTests/HealthPluginTests.swift
+++ b/ios/Tests/HealthPluginTests/HealthPluginTests.swift
@@ -2,10 +2,12 @@ import XCTest
 @testable import HealthPlugin
 
 class HealthTests: XCTestCase {
-    func testReadSamplePayloadIncludesFiniteValue() {
+    func testReadSamplePayloadIncludesFiniteValue() throws {
         let implementation = Health()
         let startDate = Date(timeIntervalSince1970: 0)
         let endDate = Date(timeIntervalSince1970: 60)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
         let payload = implementation.readSamplePayload(
             dataType: .oxygenSaturation,
@@ -17,6 +19,14 @@ class HealthTests: XCTestCase {
         XCTAssertEqual(payload?["dataType"] as? String, "oxygenSaturation")
         XCTAssertEqual(payload?["value"] as? Double, 0.96)
         XCTAssertEqual(payload?["unit"] as? String, "percent")
+
+        let startDateString = try XCTUnwrap(payload?["startDate"] as? String)
+        let endDateString = try XCTUnwrap(payload?["endDate"] as? String)
+        let parsedStartDate = try XCTUnwrap(formatter.date(from: startDateString))
+        let parsedEndDate = try XCTUnwrap(formatter.date(from: endDateString))
+
+        XCTAssertEqual(parsedStartDate.timeIntervalSince1970, startDate.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertEqual(parsedEndDate.timeIntervalSince1970, endDate.timeIntervalSince1970, accuracy: 0.001)
     }
 
     func testReadSamplePayloadRejectsNaNValue() {
@@ -40,6 +50,20 @@ class HealthTests: XCTestCase {
         let payload = implementation.readSamplePayload(
             dataType: .bloodGlucose,
             value: .infinity,
+            startDate: startDate,
+            endDate: startDate
+        )
+
+        XCTAssertNil(payload)
+    }
+
+    func testReadSamplePayloadRejectsNegativeInfiniteValue() {
+        let implementation = Health()
+        let startDate = Date(timeIntervalSince1970: 0)
+
+        let payload = implementation.readSamplePayload(
+            dataType: .bloodGlucose,
+            value: -.infinity,
             startDate: startDate,
             endDate: startDate
         )


### PR DESCRIPTION
## Summary
- skip iOS readSamples payloads when HealthKit returns NaN or infinite numeric values
- route sleep, mindfulness, blood pressure, and quantity sample payload creation through the same finite-value guard
- replace placeholder Swift test with finite/NaN/infinity coverage

Fixes #55

## Tests
- bun install --frozen-lockfile
- xcodebuild -scheme CapgoCapacitorHealth -destination generic/platform=iOS
- xcodebuild test -scheme CapgoCapacitorHealth -destination "platform=iOS Simulator,name=iPhone 17"
- bun run clean
- bun run docgen
- bunx tsc
- bunx rollup -c rollup.config.mjs
- bun run eslint (passes with existing unused _options warnings)
- bun run prettier -- --check
- bun scripts/check-capacitor-plugin-wiring.mjs

## Not run
- Android Gradle build locally: no Java runtime installed on this machine
- bun run swiftlint -- lint: fails on existing repo-wide Health.swift complexity/file-length violations and existing trailing whitespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health samples with invalid numeric values (NaN or infinity) are now filtered out, ensuring only valid data is returned.

* **Improvements**
  * More consistent handling of sleep and blood pressure samples and standardized sample payload formatting.

* **Tests**
  * Unit tests added/updated to verify payload validation and correct handling of sample data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-health/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->