### PR TITLE
ci: allow manual bump version runs

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,6 +1,7 @@
 name: Bump version
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -12,13 +13,13 @@ on:
 jobs:
   # Run all tests first before creating any tags
   test:
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     uses: ./.github/workflows/test.yml
 
   # Only bump version and create tag if all tests pass
   bump-version:
     needs: [test]
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: "Bump version and create tag"


### PR DESCRIPTION
## Summary
- add a manual trigger to the Bump version workflow
- keep release-commit pushes skipped while allowing manual runs to execute tests and version bump

## Verification
- bun run check:wiring
- parsed .github/workflows/bump_version.yml as YAML
- git diff --check