### PR TITLE
Add appleSleepingWristTemperature data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ Stage-level sleep segment emitted for sleep samples when platform data is availa
 
 #### HealthDataType
 
-<code>'steps' | 'distance' | 'calories' | 'heartRate' | 'weight' | 'sleep' | 'respiratoryRate' | 'oxygenSaturation' | 'restingHeartRate' | 'heartRateVariability' | 'vo2Max' | 'bloodPressure' | 'bloodGlucose' | 'bodyTemperature' | 'height' | 'flightsClimbed' | 'exerciseTime' | 'distanceCycling' | 'bodyFat' | 'basalBodyTemperature' | 'basalCalories' | 'totalCalories' | 'mindfulness' | 'workouts'</code>
+<code>'steps' | 'distance' | 'calories' | 'heartRate' | 'weight' | 'sleep' | 'respiratoryRate' | 'oxygenSaturation' | 'restingHeartRate' | 'heartRateVariability' | 'vo2Max' | 'bloodPressure' | 'bloodGlucose' | 'bodyTemperature' | 'height' | 'flightsClimbed' | 'exerciseTime' | 'distanceCycling' | 'bodyFat' | 'basalBodyTemperature' | 'appleSleepingWristTemperature' | 'basalCalories' | 'totalCalories' | 'mindfulness' | 'workouts'</code>
 
 
 #### HealthUnit

--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -574,6 +574,7 @@ enum HealthDataType: String, CaseIterable {
     case distanceCycling
     case bodyFat
     case basalBodyTemperature
+    case appleSleepingWristTemperature
     case basalCalories
     case totalCalories
     case mindfulness
@@ -637,6 +638,12 @@ enum HealthDataType: String, CaseIterable {
             identifier = .bodyFatPercentage
         case .basalBodyTemperature:
             identifier = .basalBodyTemperature
+        case .appleSleepingWristTemperature:
+            if #available(iOS 16.0, *) {
+                identifier = .appleSleepingWristTemperature
+            } else {
+                throw HealthManagerError.dataTypeUnavailable(rawValue)
+            }
         case .basalCalories:
             identifier = .basalEnergyBurned
         case .totalCalories:
@@ -679,7 +686,7 @@ enum HealthDataType: String, CaseIterable {
             return HKUnit.millimeterOfMercury()
         case .bloodGlucose:
             return HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
-        case .bodyTemperature, .basalBodyTemperature:
+        case .bodyTemperature, .basalBodyTemperature, .appleSleepingWristTemperature:
             return HKUnit.degreeCelsius()
         case .height:
             return HKUnit.meterUnit(with: .centi)
@@ -722,7 +729,7 @@ enum HealthDataType: String, CaseIterable {
             return "mmHg"
         case .bloodGlucose:
             return "mg/dL"
-        case .bodyTemperature, .basalBodyTemperature:
+        case .bodyTemperature, .basalBodyTemperature, .appleSleepingWristTemperature:
             return "celsius"
         case .height:
             return "centimeter"

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,6 +19,7 @@ export type HealthDataType =
   | 'distanceCycling'
   | 'bodyFat'
   | 'basalBodyTemperature'
+  | 'appleSleepingWristTemperature'
   | 'basalCalories'
   | 'totalCalories'
   | 'mindfulness'


### PR DESCRIPTION
## Summary
- Add `appleSleepingWristTemperature` to `HealthDataType` for Apple Watch sleeping wrist temperature (iOS 16+).
- Map the type to `HKQuantityTypeIdentifier.appleSleepingWristTemperature` with celsius units on iOS.

Closes #76

## Test plan
- [x] `bun run verify` (iOS, Android, web)
- [ ] On device/simulator (iOS 16+): authorize and read `appleSleepingWristTemperature` samples from HealthKit


Made with [Cursor](https://cursor.com)