### PR TITLE
feat: expose HKWorkout lap events in queryWorkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,18 +679,29 @@ Stage-level sleep segment emitted for sleep samples when platform data is availa
 
 #### Workout
 
-| Prop                    | Type                                                            | Description                                                                                         |
-| ----------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **`workoutType`**       | <code><a href="#workouttype">WorkoutType</a></code>             | The type of workout.                                                                                |
-| **`duration`**          | <code>number</code>                                             | Duration of the workout in seconds.                                                                 |
-| **`totalEnergyBurned`** | <code>number</code>                                             | Total energy burned in kilocalories (if available).                                                 |
-| **`totalDistance`**     | <code>number</code>                                             | Total distance in meters (if available).                                                            |
-| **`startDate`**         | <code>string</code>                                             | ISO 8601 start date of the workout.                                                                 |
-| **`endDate`**           | <code>string</code>                                             | ISO 8601 end date of the workout.                                                                   |
-| **`sourceName`**        | <code>string</code>                                             | Source name that recorded the workout.                                                              |
-| **`sourceId`**          | <code>string</code>                                             | Source bundle identifier.                                                                           |
-| **`platformId`**        | <code>string</code>                                             | Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android). |
-| **`metadata`**          | <code><a href="#record">Record</a>&lt;string, string&gt;</code> | Additional metadata (if available).                                                                 |
+| Prop                    | Type                                                            | Description                                                                                                            |
+| ----------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **`workoutType`**       | <code><a href="#workouttype">WorkoutType</a></code>             | The type of workout.                                                                                                   |
+| **`duration`**          | <code>number</code>                                             | Duration of the workout in seconds.                                                                                    |
+| **`totalEnergyBurned`** | <code>number</code>                                             | Total energy burned in kilocalories (if available).                                                                    |
+| **`totalDistance`**     | <code>number</code>                                             | Total distance in meters (if available).                                                                               |
+| **`startDate`**         | <code>string</code>                                             | ISO 8601 start date of the workout.                                                                                    |
+| **`endDate`**           | <code>string</code>                                             | ISO 8601 end date of the workout.                                                                                      |
+| **`sourceName`**        | <code>string</code>                                             | Source name that recorded the workout.                                                                                 |
+| **`sourceId`**          | <code>string</code>                                             | Source bundle identifier.                                                                                              |
+| **`platformId`**        | <code>string</code>                                             | Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android).                    |
+| **`metadata`**          | <code><a href="#record">Record</a>&lt;string, string&gt;</code> | Additional metadata (if available).                                                                                    |
+| **`workoutEvents`**     | <code>WorkoutEvent[]</code>                                     | Lap workout events when available. On iOS, includes HealthKit lap markers with per-lap duration and optional distance. |
+
+
+#### WorkoutEvent
+
+| Prop                  | Type                | Description                                                                                                                  |
+| --------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **`type`**            | <code>string</code> | <a href="#workout">Workout</a> event type. iOS returns lap events from HealthKit (`HKWorkoutEventType.lap`).                 |
+| **`date`**            | <code>string</code> | ISO 8601 timestamp of the event.                                                                                             |
+| **`durationSeconds`** | <code>number</code> | Duration of the lap interval in seconds until the next lap event or the workout end. Present for lap events returned on iOS. |
+| **`distanceMeters`**  | <code>number</code> | Lap distance in meters when HealthKit provides it on the workout event metadata (for example `HKMetadataKeyLapLength`).      |
 
 
 #### QueryWorkoutsOptions
@@ -761,6 +772,11 @@ Construct a type with a set of properties K of type T
 #### WorkoutType
 
 <code>'americanFootball' | 'australianFootball' | 'badminton' | 'baseball' | 'basketball' | 'bowling' | 'boxing' | 'climbing' | 'cricket' | 'crossTraining' | 'curling' | 'cycling' | 'dance' | 'elliptical' | 'fencing' | 'functionalStrengthTraining' | 'golf' | 'gymnastics' | 'handball' | 'hiking' | 'hockey' | 'jumpRope' | 'kickboxing' | 'lacrosse' | 'martialArts' | 'pilates' | 'racquetball' | 'rowing' | 'rugby' | 'running' | 'sailing' | 'skatingSports' | 'skiing' | 'snowboarding' | 'soccer' | 'softball' | 'squash' | 'stairClimbing' | 'strengthTraining' | 'surfing' | 'swimming' | 'swimmingPool' | 'swimmingOpenWater' | 'tableTennis' | 'tennis' | 'trackAndField' | 'traditionalStrengthTraining' | 'volleyball' | 'walking' | 'waterFitness' | 'waterPolo' | 'waterSports' | 'weightlifting' | 'wheelchair' | 'yoga' | 'archery' | 'barre' | 'cooldown' | 'coreTraining' | 'crossCountrySkiing' | 'discSports' | 'downhillSkiing' | 'equestrianSports' | 'fishing' | 'fitnessGaming' | 'flexibility' | 'handCycling' | 'highIntensityIntervalTraining' | 'hunting' | 'mindAndBody' | 'mixedCardio' | 'paddleSports' | 'pickleball' | 'play' | 'preparationAndRecovery' | 'snowSports' | 'stairs' | 'stepTraining' | 'surfingSports' | 'taiChi' | 'transition' | 'underwaterDiving' | 'wheelchairRunPace' | 'wheelchairWalkPace' | 'wrestling' | 'cardioDance' | 'socialDance' | 'backExtension' | 'barbellShoulderPress' | 'benchPress' | 'benchSitUp' | 'bikingStationary' | 'bootCamp' | 'burpee' | 'calisthenics' | 'crunch' | 'dancing' | 'deadlift' | 'dumbbellCurlLeftArm' | 'dumbbellCurlRightArm' | 'dumbbellFrontRaise' | 'dumbbellLateralRaise' | 'dumbbellTricepsExtensionLeftArm' | 'dumbbellTricepsExtensionRightArm' | 'dumbbellTricepsExtensionTwoArm' | 'exerciseClass' | 'forwardTwist' | 'frisbeedisc' | 'guidedBreathing' | 'iceHockey' | 'iceSkating' | 'jumpingJack' | 'latPullDown' | 'lunge' | 'meditation' | 'paddling' | 'paraGliding' | 'plank' | 'rockClimbing' | 'rollerHockey' | 'rowingMachine' | 'runningTreadmill' | 'scubaDiving' | 'skating' | 'snowshoeing' | 'stairClimbingMachine' | 'stretching' | 'upperTwist' | 'other'</code>
+
+
+#### WorkoutEventType
+
+<code>'lap' | 'pause' | 'segment' | 'marker'</code>
 
 
 #### BucketType

--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -1667,6 +1667,28 @@ final class Health {
             }
         }
 
+        if let events = workout.workoutEvents, !events.isEmpty {
+            let lapEvents = events.filter { $0.type == .lap }
+            if !lapEvents.isEmpty {
+                payload["workoutEvents"] = lapEvents.enumerated().map { index, event in
+                    let nextDate = index + 1 < lapEvents.count
+                        ? lapEvents[index + 1].date
+                        : workout.endDate
+                    let durationSeconds = max(0, nextDate.timeIntervalSince(event.date))
+                    var lapPayload: [String: Any] = [
+                        "type": "lap",
+                        "date": isoFormatter.string(from: event.date),
+                        "durationSeconds": durationSeconds,
+                    ]
+                    if let metadata = event.metadata,
+                       let lapLength = metadata[HKMetadataKeyLapLength] as? HKQuantity {
+                        lapPayload["distanceMeters"] = lapLength.doubleValue(for: HKUnit.meter())
+                    }
+                    return lapPayload
+                }
+            }
+        }
+
         return payload
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -305,6 +305,28 @@ export interface QueryWorkoutsOptions {
   anchor?: string;
 }
 
+export type WorkoutEventType = 'lap' | 'pause' | 'segment' | 'marker';
+
+export interface WorkoutEvent {
+  /**
+   * Workout event type.
+   * iOS returns lap events from HealthKit (`HKWorkoutEventType.lap`).
+   */
+  type: WorkoutEventType | string;
+  /** ISO 8601 timestamp of the event. */
+  date: string;
+  /**
+   * Duration of the lap interval in seconds until the next lap event or the workout end.
+   * Present for lap events returned on iOS.
+   */
+  durationSeconds?: number;
+  /**
+   * Lap distance in meters when HealthKit provides it on the workout event metadata
+   * (for example `HKMetadataKeyLapLength`).
+   */
+  distanceMeters?: number;
+}
+
 export interface Workout {
   /** The type of workout. */
   workoutType: WorkoutType;
@@ -326,6 +348,11 @@ export interface Workout {
   platformId?: string;
   /** Additional metadata (if available). */
   metadata?: Record<string, string>;
+  /**
+   * Lap workout events when available.
+   * On iOS, includes HealthKit lap markers with per-lap duration and optional distance.
+   */
+  workoutEvents?: WorkoutEvent[];
 }
 
 export interface QueryWorkoutsResult {


### PR DESCRIPTION
## Summary
- Map HealthKit `HKWorkoutEventType.lap` markers into each workout's `workoutEvents` array on iOS (`type`, `date`, `durationSeconds`, optional `distanceMeters` from `HKMetadataKeyLapLength`).
- Add `WorkoutEvent` / `WorkoutEventType` to the public TypeScript API and regenerate docgen README sections.

Closes #64

## Test plan
- [x] `bun run verify` (iOS Swift build, Android Gradle, web bundle)
- [ ] Manual: `queryWorkouts` on a workout with Apple Watch laps returns `workoutEvents` with expected durations


Made with [Cursor](https://cursor.com)