### PR TITLE
fix(ios): don't request share authorization for the raw bloodPressure correlation type

### DIFF
--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -1239,6 +1239,20 @@ final class Health {
         var denied: [HealthDataType] = []
 
         for type in types {
+            // Blood pressure share authorization is tracked on the component quantity
+            // types, not the correlation type (which always reports notDetermined).
+            if type == .bloodPressure {
+                if let systolicType = HKObjectType.quantityType(forIdentifier: .bloodPressureSystolic),
+                   let diastolicType = HKObjectType.quantityType(forIdentifier: .bloodPressureDiastolic),
+                   healthStore.authorizationStatus(for: systolicType) == .sharingAuthorized,
+                   healthStore.authorizationStatus(for: diastolicType) == .sharingAuthorized {
+                    authorized.append(type)
+                } else {
+                    denied.append(type)
+                }
+                continue
+            }
+
             guard let sampleType = try? type.sampleType() else {
                 denied.append(type)
                 continue
@@ -1408,6 +1422,18 @@ final class Health {
     private func sampleTypes(for dataTypes: [HealthDataType]) throws -> Set<HKSampleType> {
         var set = Set<HKSampleType>()
         for dataType in dataTypes {
+            // Blood pressure is an HKCorrelationType; requesting SHARE authorization for a
+            // correlation type throws an uncatchable NSException. Substitute the component
+            // quantity types instead, mirroring readAuthorizationObjectTypes(for:).
+            if dataType == .bloodPressure {
+                guard let systolicType = HKObjectType.quantityType(forIdentifier: .bloodPressureSystolic),
+                      let diastolicType = HKObjectType.quantityType(forIdentifier: .bloodPressureDiastolic) else {
+                    throw HealthManagerError.dataTypeUnavailable(dataType.rawValue)
+                }
+                set.insert(systolicType)
+                set.insert(diastolicType)
+                continue
+            }
             let type = try dataType.sampleType()
             set.insert(type)
         }


### PR DESCRIPTION
Fixes #81.

Requesting SHARE authorization for `HKCorrelationType(.bloodPressure)` throws an uncatchable NSException (`-[HKHealthStoreImplementation _throwIfAuthorizationDisallowedForSharing:types:]`), so any `requestAuthorization()` call with `'bloodPressure'` in the `write` array aborts the app before the permission sheet appears (100% repro, observed on iOS 26.4.1 with 8.6.2; code unchanged on `main`).

### Changes

- `sampleTypes(for:)`: for `.bloodPressure`, insert the `bloodPressureSystolic` / `bloodPressureDiastolic` component quantity types into the `toShare` set instead of the raw correlation type — the same substitution the read path already does in `readAuthorizationObjectTypes(for:)` (cf. #38).
- `writeAuthorizationStatus(for:)`: evaluate blood-pressure write status on the two component quantity types; `authorizationStatus(for:)` on the correlation type always returns `notDetermined`, so `bloodPressure` could previously never appear in `writeAuthorized`.

No change to the save path — `saveSample` already writes an `HKCorrelation` with both component quantity samples, which works once share authorization can actually be granted.

### Testing

- `swiftc -parse` clean; the same change applied to 8.6.2 as a patch-package patch builds in a production Capacitor app.
- The crash itself (SIGABRT on `requestAuthorization` with `bloodPressure` in `write`) was reproduced 100% on a real device before removing BP from the write array.
- On-device verification of this patch (permission sheet appears with Blood Pressure under write; paired BP saves land in Apple Health) is scheduled on our side — will report back on this PR once done. Happy to adjust if maintainers prefer a different shape for the substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blood pressure authorization handling by verifying access to both systolic and diastolic measurements.
  * Updated blood pressure data access requests to use the appropriate component measurements, improving compatibility with HealthKit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->