### PR TITLE
fix(ios): add missing vo2Max case to HealthDataType

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ await Health.saveSample({
 | `oxygenSaturation`      | `percent`     | Blood oxygen saturation (SpO2)                           |
 | `restingHeartRate`      | `bpm`         | Resting heart rate                                       |
 | `heartRateVariability`  | `millisecond` | Heart rate variability (HRV)                             |
-| `vo2Max`                | `mL/min/kg`   | VO2 max (Android Health Connect)                         |
+| `vo2Max`                | `mL/min/kg`   | VO2 max                                                  |
 | `bloodPressure`         | `mmHg`        | Blood pressure (requires systolic/diastolic values)      |
 | `bloodGlucose`          | `mg/dL`       | Blood glucose level                                      |
 | `bodyTemperature`       | `celsius`     | Body temperature                                         |

--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -565,6 +565,7 @@ enum HealthDataType: String, CaseIterable {
     case oxygenSaturation
     case restingHeartRate
     case heartRateVariability
+    case vo2Max
     case bloodPressure
     case bloodGlucose
     case bodyTemperature
@@ -622,6 +623,8 @@ enum HealthDataType: String, CaseIterable {
             identifier = .restingHeartRate
         case .heartRateVariability:
             identifier = .heartRateVariabilitySDNN
+        case .vo2Max:
+            identifier = .vo2Max
         case .bloodGlucose:
             identifier = .bloodGlucose
         case .bodyTemperature:
@@ -680,6 +683,9 @@ enum HealthDataType: String, CaseIterable {
             return HKUnit.percent()
         case .heartRateVariability:
             return HKUnit.secondUnit(with: .milli)
+        case .vo2Max:
+            return HKUnit.literUnit(with: .milli)
+                .unitDivided(by: HKUnit.gramUnit(with: .kilo).unitMultiplied(by: HKUnit.minute()))
         case .sleep:
             return HKUnit.minute()
         case .bloodPressure:
@@ -723,6 +729,8 @@ enum HealthDataType: String, CaseIterable {
             return "percent"
         case .heartRateVariability:
             return "millisecond"
+        case .vo2Max:
+            return "mL/min/kg"
         case .sleep:
             return "minute"
         case .bloodPressure:


### PR DESCRIPTION
## What
- Adds the missing `vo2Max` case to the iOS `HealthDataType` enum: quantity identifier `.vo2Max`, canonical `ml/(kg·min)` HKUnit, and the existing `"mL/min/kg"` unit identifier string.
- README: the `vo2Max` row no longer says Android-only.

## Why
`vo2Max` is in the TypeScript `HealthDataType` union, implemented on Android, and documented in the README — but the iOS enum never gained a case for it. On iOS, `parseDataType` throws `invalidDataType("vo2Max")`, so `readSamples`, `requestAuthorization` (any list containing it), and `queryAggregated` all fail for a documented type.

## How
Minimal-diff addition following the surrounding style: enum case + `quantityType()` mapping + `defaultUnit` + `unitIdentifier`. `queryAggregated` continues to reject it through the existing per-type gate ("Use readSamples instead"), matching Android's behavior for VO2 max.

## Testing
- `bun run build` (tsc + rollup + docgen) and the eslint/prettier lint pass locally.
- Consumed via a fork pin in a production Capacitor 8 iOS app (remote-URL shell), where `readSamples({ dataType: 'vo2Max' })` returns samples after this fix.

## Not Tested
- No new unit tests (the repo has no per-type test harness for the Swift enum); relying on CI's iOS build + the exhaustive-switch compile checks.

---
Transparency per AGENTS.md: this PR was written by an AI agent (Claude) operating a personal-project integration, reviewed in use by the account owner.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-health/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iOS support for retrieving VO₂ max health data.
  * VO₂ max values now include the correct measurement unit: mL/min/kg.

* **Documentation**
  * Updated the supported data types documentation with a platform-neutral description for VO₂ max.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->