### PR TITLE
feat: add appleStandHour (iOS), dietaryWater and dietaryEnergyConsumed data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ await Health.saveSample({
 | `basalCalories`         | `kilocalorie` | Basal metabolic rate / resting energy                    |
 | `totalCalories`         | `kilocalorie` | Total energy burned (active + basal)                     |
 | `mindfulness`           | `minute`      | Mindfulness / meditation sessions                        |
-| `appleStandHour`        | `count`       | Apple Watch stand hours (iOS only; value 1 = stood)      |
+| `appleStandHour`        | `count`       | Apple Watch stand hours (iOS only, read-only; 1 = stood) |
 | `dietaryWater`          | `liter`       | Water consumed                                           |
 | `dietaryEnergyConsumed` | `kilocalorie` | Dietary energy (calories) consumed                       |
 | `workouts`              | N/A           | Workout sessions (read-only, use with `queryWorkouts()`) |
@@ -776,7 +776,9 @@ Stage-level sleep segment emitted for sleep samples when platform data is availa
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
+<code>{
+ [P in K]: T;
+ }</code>
 
 
 #### WorkoutType
@@ -793,7 +795,9 @@ Construct a type with a set of properties K of type T
 
 Make all properties in T optional
 
-<code>{ [P in keyof T]?: T[P]; }</code>
+<code>{
+ [P in keyof T]?: T[P];
+ }</code>
 
 
 #### AggregationType

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ await Health.saveSample({
 | `basalCalories`         | `kilocalorie` | Basal metabolic rate / resting energy                    |
 | `totalCalories`         | `kilocalorie` | Total energy burned (active + basal)                     |
 | `mindfulness`           | `minute`      | Mindfulness / meditation sessions                        |
+| `appleStandHour`        | `count`       | Apple Watch stand hours (iOS only; value 1 = stood)      |
+| `dietaryWater`          | `liter`       | Water consumed                                           |
+| `dietaryEnergyConsumed` | `kilocalorie` | Dietary energy (calories) consumed                       |
 | `workouts`              | N/A           | Workout sessions (read-only, use with `queryWorkouts()`) |
 
 All write operations expect the default unit shown above. On Android the `metadata` option is currently ignored by Health Connect.
@@ -382,7 +385,7 @@ hr.forEach(sample => {
 });
 ```
 
-**Note:** Aggregated queries are not supported for sleep, respiratory rate, oxygen saturation, heart rate variability, and VO2 max data types. These measurements should use `readSamples()`, not `queryAggregated()`. Aggregation is supported for: steps, distance, calories, heart rate, weight, and resting heart rate.
+**Note:** Aggregated queries are not supported for sleep, respiratory rate, oxygen saturation, heart rate variability, and VO2 max data types. These measurements should use `readSamples()`, not `queryAggregated()`. Aggregation is supported for: steps, distance, calories, dietary water, dietary energy consumed, heart rate, weight, and resting heart rate.
 
 ## API
 
@@ -618,22 +621,23 @@ Supported on iOS (HealthKit) and Android (Health Connect).
 
 #### HealthSample
 
-| Prop                    | Type                                                      | Description                                                                                         |
-| ----------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **`dataType`**          | <code><a href="#healthdatatype">HealthDataType</a></code> |                                                                                                     |
-| **`value`**             | <code>number</code>                                       |                                                                                                     |
-| **`unit`**              | <code><a href="#healthunit">HealthUnit</a></code>         |                                                                                                     |
-| **`startDate`**         | <code>string</code>                                       |                                                                                                     |
-| **`endDate`**           | <code>string</code>                                       |                                                                                                     |
-| **`sourceName`**        | <code>string</code>                                       |                                                                                                     |
-| **`sourceId`**          | <code>string</code>                                       |                                                                                                     |
-| **`platformId`**        | <code>string</code>                                       | Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android). |
-| **`sleepState`**        | <code><a href="#sleepstate">SleepState</a></code>         | For sleep data, indicates the sleep state (e.g., 'asleep', 'awake', 'rem', 'deep', 'light').        |
-| **`stages`**            | <code>SleepStage[]</code>                                 | For sleep data, individual sleep stages when the platform exposes stage-level data.                 |
-| **`hasStageData`**      | <code>boolean</code>                                      | For sleep data, indicates whether stage-level data was emitted.                                     |
-| **`systolic`**          | <code>number</code>                                       | For blood pressure data, the systolic value in mmHg.                                                |
-| **`diastolic`**         | <code>number</code>                                       | For blood pressure data, the diastolic value in mmHg.                                               |
-| **`measurementMethod`** | <code>number</code>                                       | For VO2 max data on Android, Health Connect's measurement method enum value.                        |
+| Prop                    | Type                                                      | Description                                                                                                                                                                                                  |
+| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`dataType`**          | <code><a href="#healthdatatype">HealthDataType</a></code> |                                                                                                                                                                                                              |
+| **`value`**             | <code>number</code>                                       |                                                                                                                                                                                                              |
+| **`unit`**              | <code><a href="#healthunit">HealthUnit</a></code>         |                                                                                                                                                                                                              |
+| **`startDate`**         | <code>string</code>                                       |                                                                                                                                                                                                              |
+| **`endDate`**           | <code>string</code>                                       |                                                                                                                                                                                                              |
+| **`sourceName`**        | <code>string</code>                                       |                                                                                                                                                                                                              |
+| **`sourceId`**          | <code>string</code>                                       |                                                                                                                                                                                                              |
+| **`platformId`**        | <code>string</code>                                       | Platform-specific unique identifier (HealthKit UUID on iOS, Health Connect metadata ID on Android).                                                                                                          |
+| **`sleepState`**        | <code><a href="#sleepstate">SleepState</a></code>         | For sleep data, indicates the sleep state (e.g., 'asleep', 'awake', 'rem', 'deep', 'light').                                                                                                                 |
+| **`standState`**        | <code>'stood' \| 'idle'</code>                            | For Apple Stand Hour data (iOS only), whether the hour counted as stood or idle. `value` is normalized to 1 for stood and 0 for idle, so summing values per day yields the Activity ring's stand-hour count. |
+| **`stages`**            | <code>SleepStage[]</code>                                 | For sleep data, individual sleep stages when the platform exposes stage-level data.                                                                                                                          |
+| **`hasStageData`**      | <code>boolean</code>                                      | For sleep data, indicates whether stage-level data was emitted.                                                                                                                                              |
+| **`systolic`**          | <code>number</code>                                       | For blood pressure data, the systolic value in mmHg.                                                                                                                                                         |
+| **`diastolic`**         | <code>number</code>                                       | For blood pressure data, the diastolic value in mmHg.                                                                                                                                                        |
+| **`measurementMethod`** | <code>number</code>                                       | For VO2 max data on Android, Health Connect's measurement method enum value.                                                                                                                                 |
 
 
 #### SleepStage
@@ -755,12 +759,12 @@ Stage-level sleep segment emitted for sleep samples when platform data is availa
 
 #### HealthDataType
 
-<code>'steps' | 'distance' | 'calories' | 'heartRate' | 'weight' | 'sleep' | 'respiratoryRate' | 'oxygenSaturation' | 'restingHeartRate' | 'heartRateVariability' | 'vo2Max' | 'bloodPressure' | 'bloodGlucose' | 'bodyTemperature' | 'height' | 'flightsClimbed' | 'exerciseTime' | 'distanceCycling' | 'bodyFat' | 'basalBodyTemperature' | 'appleSleepingWristTemperature' | 'basalCalories' | 'totalCalories' | 'mindfulness' | 'workouts'</code>
+<code>'steps' | 'distance' | 'calories' | 'heartRate' | 'weight' | 'sleep' | 'respiratoryRate' | 'oxygenSaturation' | 'restingHeartRate' | 'heartRateVariability' | 'vo2Max' | 'bloodPressure' | 'bloodGlucose' | 'bodyTemperature' | 'height' | 'flightsClimbed' | 'exerciseTime' | 'distanceCycling' | 'bodyFat' | 'basalBodyTemperature' | 'appleSleepingWristTemperature' | 'basalCalories' | 'totalCalories' | 'mindfulness' | 'appleStandHour' | 'dietaryWater' | 'dietaryEnergyConsumed' | 'workouts'</code>
 
 
 #### HealthUnit
 
-<code>'count' | 'meter' | 'kilocalorie' | 'bpm' | 'kilogram' | 'minute' | 'percent' | 'millisecond' | 'mL/min/kg' | 'mmHg' | 'mg/dL' | 'celsius' | 'fahrenheit' | 'centimeter'</code>
+<code>'count' | 'meter' | 'kilocalorie' | 'bpm' | 'kilogram' | 'minute' | 'percent' | 'millisecond' | 'mL/min/kg' | 'mmHg' | 'mg/dL' | 'celsius' | 'fahrenheit' | 'centimeter' | 'liter'</code>
 
 
 #### SleepState

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -41,6 +41,10 @@
     <uses-permission android:name="android.permission.health.WRITE_TOTAL_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_MINDFULNESS" />
     <uses-permission android:name="android.permission.health.WRITE_MINDFULNESS" />
+    <uses-permission android:name="android.permission.health.READ_HYDRATION" />
+    <uses-permission android:name="android.permission.health.WRITE_HYDRATION" />
+    <uses-permission android:name="android.permission.health.READ_NUTRITION" />
+    <uses-permission android:name="android.permission.health.WRITE_NUTRITION" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
 
     <!-- Query for Health Connect availability -->

--- a/android/src/main/java/app/capgo/plugin/health/HealthDataType.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthDataType.kt
@@ -14,7 +14,9 @@ import androidx.health.connect.client.records.FloorsClimbedRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
 import androidx.health.connect.client.records.HeightRecord
+import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.MindfulnessSessionRecord
+import androidx.health.connect.client.records.NutritionRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
@@ -53,7 +55,13 @@ enum class HealthDataType(
     BASAL_BODY_TEMPERATURE("basalBodyTemperature", BasalBodyTemperatureRecord::class, "celsius"),
     BASAL_CALORIES("basalCalories", BasalMetabolicRateRecord::class, "kilocalorie"),
     TOTAL_CALORIES("totalCalories", TotalCaloriesBurnedRecord::class, "kilocalorie"),
-    MINDFULNESS("mindfulness", MindfulnessSessionRecord::class, "minute");
+    MINDFULNESS("mindfulness", MindfulnessSessionRecord::class, "minute"),
+
+    // appleStandHour is deliberately absent: Health Connect has no stand-hour
+    // record, so Android rejects it as an unsupported data type (same
+    // precedent as exerciseTime / appleSleepingWristTemperature).
+    HYDRATION("dietaryWater", HydrationRecord::class, "liter"),
+    DIETARY_ENERGY("dietaryEnergyConsumed", NutritionRecord::class, "kilocalorie");
 
     val readPermission: String
         get() = HealthPermission.getReadPermission(recordClass)

--- a/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
@@ -421,7 +421,11 @@ class HealthManager {
                 )
                 samples.add(record.startTime to payload)
             }
-            HealthDataType.DIETARY_ENERGY -> readRecords(client, NutritionRecord::class, startTime, endTime, limit) { record ->
+            // Paginate the (bounded) time range without the fetch cap: null-energy
+            // records are skipped below, so counting FETCHED records against the
+            // limit could under-deliver; the shared sort/take(limit) at the end of
+            // readSamples still enforces the requested cap on emitted samples.
+            HealthDataType.DIETARY_ENERGY -> readRecords(client, NutritionRecord::class, startTime, endTime, 0) { record ->
                 // NutritionRecord.energy is nullable — skip records without it.
                 val energy = record.energy
                 if (energy != null) {

--- a/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
@@ -21,7 +21,9 @@ import androidx.health.connect.client.records.FloorsClimbedRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
 import androidx.health.connect.client.records.HeightRecord
+import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.MindfulnessSessionRecord
+import androidx.health.connect.client.records.NutritionRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
@@ -39,6 +41,7 @@ import androidx.health.connect.client.units.Length
 import androidx.health.connect.client.units.Mass
 import androidx.health.connect.client.units.Percentage
 import androidx.health.connect.client.units.Power
+import androidx.health.connect.client.units.Volume
 import com.getcapacitor.JSArray
 import com.getcapacitor.JSObject
 import java.time.Duration
@@ -408,6 +411,30 @@ class HealthManager {
                 )
                 samples.add(record.startTime to payload)
             }
+            HealthDataType.HYDRATION -> readRecords(client, HydrationRecord::class, startTime, endTime, limit) { record ->
+                val payload = createSamplePayload(
+                    dataType,
+                    record.startTime,
+                    record.endTime,
+                    record.volume.inLiters,
+                    record.metadata
+                )
+                samples.add(record.startTime to payload)
+            }
+            HealthDataType.DIETARY_ENERGY -> readRecords(client, NutritionRecord::class, startTime, endTime, limit) { record ->
+                // NutritionRecord.energy is nullable — skip records without it.
+                val energy = record.energy
+                if (energy != null) {
+                    val payload = createSamplePayload(
+                        dataType,
+                        record.startTime,
+                        record.endTime,
+                        energy.inKilocalories,
+                        record.metadata
+                    )
+                    samples.add(record.startTime to payload)
+                }
+            }
         }
 
         val sorted = samples.sortedBy { it.first }
@@ -682,6 +709,28 @@ class HealthManager {
                 )
                 client.insertRecords(listOf(record))
             }
+            HealthDataType.HYDRATION -> {
+                val record = HydrationRecord(
+                    startTime = startTime,
+                    startZoneOffset = zoneOffset(startTime),
+                    endTime = endTime,
+                    endZoneOffset = zoneOffset(endTime),
+                    volume = Volume.liters(value),
+                    metadata = recordMetadata
+                )
+                client.insertRecords(listOf(record))
+            }
+            HealthDataType.DIETARY_ENERGY -> {
+                val record = NutritionRecord(
+                    startTime = startTime,
+                    startZoneOffset = zoneOffset(startTime),
+                    endTime = endTime,
+                    endZoneOffset = zoneOffset(endTime),
+                    energy = Energy.kilocalories(value),
+                    metadata = recordMetadata
+                )
+                client.insertRecords(listOf(record))
+            }
         }
     }
 
@@ -753,7 +802,9 @@ private fun createSamplePayload(
         val supportedAggregations = when (dataType) {
             HealthDataType.STEPS,
             HealthDataType.DISTANCE,
-            HealthDataType.CALORIES -> setOf("sum")
+            HealthDataType.CALORIES,
+            HealthDataType.HYDRATION,
+            HealthDataType.DIETARY_ENERGY -> setOf("sum")
             HealthDataType.HEART_RATE,
             HealthDataType.WEIGHT,
             HealthDataType.RESTING_HEART_RATE -> setOf("average", "min", "max")
@@ -772,6 +823,8 @@ private fun createSamplePayload(
         HealthDataType.HEART_RATE -> setOf(HeartRateRecord.BPM_AVG, HeartRateRecord.BPM_MAX, HeartRateRecord.BPM_MIN)
         HealthDataType.WEIGHT -> setOf(WeightRecord.WEIGHT_AVG, WeightRecord.WEIGHT_MAX, WeightRecord.WEIGHT_MIN)
         HealthDataType.RESTING_HEART_RATE -> setOf(RestingHeartRateRecord.BPM_AVG, RestingHeartRateRecord.BPM_MAX, RestingHeartRateRecord.BPM_MIN)
+        HealthDataType.HYDRATION -> setOf(HydrationRecord.VOLUME_TOTAL)
+        HealthDataType.DIETARY_ENERGY -> setOf(NutritionRecord.ENERGY_TOTAL)
         else -> throw IllegalArgumentException("Unsupported data type for aggregation: ${dataType.identifier}")
     }
 
@@ -798,6 +851,8 @@ private fun createSamplePayload(
                 "min" -> result[RestingHeartRateRecord.BPM_MIN]?.toDouble()
                 else -> null
             }
+            HealthDataType.HYDRATION -> result[HydrationRecord.VOLUME_TOTAL]?.inLiters
+            HealthDataType.DIETARY_ENERGY -> result[NutritionRecord.ENERGY_TOTAL]?.inKilocalories
             else -> null
         }
     }

--- a/ios/Sources/HealthPlugin/Health.swift
+++ b/ios/Sources/HealthPlugin/Health.swift
@@ -578,6 +578,9 @@ enum HealthDataType: String, CaseIterable {
     case basalCalories
     case totalCalories
     case mindfulness
+    case appleStandHour
+    case dietaryWater
+    case dietaryEnergyConsumed
 
     func sampleType() throws -> HKSampleType {
         switch self {
@@ -593,6 +596,11 @@ enum HealthDataType: String, CaseIterable {
             return type
         case .mindfulness:
             guard let type = HKObjectType.categoryType(forIdentifier: .mindfulSession) else {
+                throw HealthManagerError.dataTypeUnavailable(rawValue)
+            }
+            return type
+        case .appleStandHour:
+            guard let type = HKObjectType.categoryType(forIdentifier: .appleStandHour) else {
                 throw HealthManagerError.dataTypeUnavailable(rawValue)
             }
             return type
@@ -648,12 +656,18 @@ enum HealthDataType: String, CaseIterable {
             identifier = .basalEnergyBurned
         case .totalCalories:
             identifier = .activeEnergyBurned
+        case .dietaryWater:
+            identifier = .dietaryWater
+        case .dietaryEnergyConsumed:
+            identifier = .dietaryEnergyConsumed
         case .sleep:
             throw HealthManagerError.invalidDataType("Sleep is a category type, not a quantity type")
         case .bloodPressure:
             throw HealthManagerError.invalidDataType("Blood pressure is a correlation type, not a quantity type")
         case .mindfulness:
             throw HealthManagerError.invalidDataType("Mindfulness is a category type, not a quantity type")
+        case .appleStandHour:
+            throw HealthManagerError.invalidDataType("Apple Stand Hour is a category type, not a quantity type")
         }
 
         guard let type = HKObjectType.quantityType(forIdentifier: identifier) else {
@@ -704,6 +718,12 @@ enum HealthDataType: String, CaseIterable {
             return HKUnit.kilocalorie()
         case .mindfulness:
             return HKUnit.minute()
+        case .appleStandHour:
+            return HKUnit.count()
+        case .dietaryWater:
+            return HKUnit.liter()
+        case .dietaryEnergyConsumed:
+            return HKUnit.kilocalorie()
         }
     }
 
@@ -747,6 +767,12 @@ enum HealthDataType: String, CaseIterable {
             return "kilocalorie"
         case .mindfulness:
             return "minute"
+        case .appleStandHour:
+            return "count"
+        case .dietaryWater:
+            return "liter"
+        case .dietaryEnergyConsumed:
+            return "kilocalorie"
         }
     }
 
@@ -950,6 +976,48 @@ final class Health {
                     ) else {
                         return nil
                     }
+
+                    self.addSampleMetadata(sample, to: &payload)
+
+                    return payload
+                }
+
+                completion(.success(results))
+            }
+            healthStore.execute(query)
+            return
+        }
+
+        // Handle Apple Stand Hours as a category sample. Each sample spans one
+        // hour; HKCategoryValueAppleStandHour.stood has raw value 0, so emit a
+        // normalized value (stood = 1, idle = 0) plus a standState label —
+        // summing value per day yields the Activity ring's stand-hour count.
+        if dataType == .appleStandHour {
+            let query = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: queryLimit, sortDescriptors: [sortDescriptor]) { [weak self] _, samples, error in
+                guard let self = self else { return }
+
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+
+                guard let categorySamples = samples as? [HKCategorySample] else {
+                    completion(.success([]))
+                    return
+                }
+
+                let results = categorySamples.compactMap { sample -> [String: Any]? in
+                    let stood = sample.value == HKCategoryValueAppleStandHour.stood.rawValue
+                    guard var payload = self.readSamplePayload(
+                        dataType: dataType,
+                        value: stood ? 1.0 : 0.0,
+                        startDate: sample.startDate,
+                        endDate: sample.endDate
+                    ) else {
+                        return nil
+                    }
+
+                    payload["standState"] = stood ? "stood" : "idle"
 
                     self.addSampleMetadata(sample, to: &payload)
 
@@ -1393,6 +1461,8 @@ final class Health {
             return HKUnit.secondUnit(with: .milli)
         case "minute":
             return HKUnit.minute()
+        case "liter":
+            return HKUnit.liter()
         default:
             return dataType.defaultUnit
         }
@@ -1478,7 +1548,7 @@ final class Health {
             let supportedAggregations: Set<String>
             let defaultAggregation: String
             switch dataType {
-            case .steps, .distance, .calories:
+            case .steps, .distance, .calories, .dietaryWater, .dietaryEnergyConsumed:
                 supportedAggregations = ["sum"]
                 defaultAggregation = "sum"
             case .heartRate, .weight, .restingHeartRate:

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,6 +23,9 @@ export type HealthDataType =
   | 'basalCalories'
   | 'totalCalories'
   | 'mindfulness'
+  | 'appleStandHour'
+  | 'dietaryWater'
+  | 'dietaryEnergyConsumed'
   | 'workouts';
 
 export type HealthUnit =
@@ -39,7 +42,8 @@ export type HealthUnit =
   | 'mg/dL'
   | 'celsius'
   | 'fahrenheit'
-  | 'centimeter';
+  | 'centimeter'
+  | 'liter';
 
 export interface AuthorizationOptions {
   /** Data types that should be readable after authorization. */
@@ -135,6 +139,12 @@ export interface HealthSample {
   platformId?: string;
   /** For sleep data, indicates the sleep state (e.g., 'asleep', 'awake', 'rem', 'deep', 'light'). */
   sleepState?: SleepState;
+  /**
+   * For Apple Stand Hour data (iOS only), whether the hour counted as stood or idle.
+   * `value` is normalized to 1 for stood and 0 for idle, so summing values per day
+   * yields the Activity ring's stand-hour count.
+   */
+  standState?: 'stood' | 'idle';
   /** For sleep data, individual sleep stages when the platform exposes stage-level data. */
   stages?: SleepStage[];
   /** For sleep data, indicates whether stage-level data was emitted. */


### PR DESCRIPTION
## What
Three new data types:
- **`appleStandHour`** (iOS only): Apple Watch stand hours via `readSamples`, following the existing sleep/mindfulness category-type pattern. Each emitted sample is one hour with `value` normalized to `1` (stood) / `0` (idle) plus a `standState: 'stood' | 'idle'` field — summing `value` per local day reproduces the Activity ring's stand-hour count. Android has no Health Connect equivalent, so it deliberately stays out of the Android enum and rejects as an unsupported type (same precedent as `exerciseTime`).
- **`dietaryWater`**: `.dietaryWater` / `HydrationRecord`, new `'liter'` HealthUnit, `sum` aggregation on both platforms.
- **`dietaryEnergyConsumed`**: `.dietaryEnergyConsumed` / `NutritionRecord` (nullable `energy` guarded on read; writes construct the record with energy + time range only), `kilocalorie`, `sum` aggregation on both platforms.

Plus: Android manifest gains `READ/WRITE_HYDRATION` + `READ/WRITE_NUTRITION`; README's hand-maintained data-type table and aggregation note updated; docgen sections regenerated via the build.

## Why
Hydration and dietary-energy tracking are common health-app needs with first-class HealthKit/Health Connect types, and stand hours are one of the three Apple Watch rings — none were reachable through the plugin. `value = raw` was deliberately avoided for stand hours because `HKCategoryValueAppleStandHour.stood.rawValue == 0`, which would make the intuitive "sum the values" read produce inverted results.

## How
Followed the existing per-type touchpoints exactly: enum cases + `sampleType()` category branch + `quantityType()` mappings/throw-stub + `defaultUnit`/`unitIdentifier` + `unit(for:)` `"liter"` + a `readSamples` category block mirroring sleep, and the iOS sum-aggregation gate extended in step with Android's `validateAggregation`/`aggregateMetrics`/`aggregateValue` so `queryAggregated` behaves identically on both platforms.

## Testing
- `bun run build` (tsc + rollup + docgen) and eslint/prettier pass locally.
- iOS path consumed via a fork pin in a production Capacitor 8 app: `readSamples('appleStandHour')` matches the watch ring after per-day summing; `queryAggregated('dietaryWater')` returns day buckets.

## Not Tested
- Android branches compile-checked by CI only (no Health Connect device on hand) — the exhaustive `when` blocks force complete coverage, and the Hydration/Nutrition record shapes follow the neighboring branches.
- `saveSample` write paths for the new types (added for exhaustiveness/completeness; my use case is read-only).

---
Transparency per AGENTS.md: this PR was written by an AI agent (Claude) operating a personal-project integration, reviewed in use by the account owner. Independent of #85 (applies cleanly to main); happy to rebase if both merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-health/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

