### PR TITLE
fix(android): reject PluginCall on uncaught Health Connect failures (#92)

### DIFF
--- a/android/src/main/java/app/capgo/plugin/health/HealthPlugin.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthPlugin.kt
@@ -18,6 +18,7 @@ import java.time.Instant
 import java.time.Duration
 import java.time.format.DateTimeParseException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -26,9 +27,14 @@ import kotlinx.coroutines.launch
 
 @CapacitorPlugin(name = "Health")
 class HealthPlugin : Plugin() {
-    private val pluginVersion = "7.2.14"
+    private val pluginVersion = "8.10.0"
     private val manager = HealthManager()
-    private val pluginScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val pluginScope = CoroutineScope(
+        SupervisorJob() + Dispatchers.Main.immediate +
+            CoroutineExceptionHandler { _, throwable ->
+                Log.e(TAG, "Unhandled coroutine failure", throwable)
+            },
+    )
     private val permissionContract = PermissionController.createRequestPermissionResultContract()
 
     // Store pending request data for callback
@@ -36,6 +42,24 @@ class HealthPlugin : Plugin() {
     private var pendingWriteTypes: List<HealthDataType> = emptyList()
     private var pendingIncludeWorkouts: Boolean = false
     private var pendingIncludeHistoryAccess: Boolean = false
+
+    /**
+     * Launch work on [pluginScope] and always settle [this] PluginCall on failure.
+     * Without this, exceptions escaping a plain `launch` hit the thread's default
+     * handler and kill the host app (e.g. Health Connect IPC rate limits).
+     */
+    private inline fun PluginCall.launchSafely(crossinline block: suspend () -> Unit) {
+        pluginScope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Log.e(TAG, "Health Connect call failed", e)
+                reject(e.message ?: "Health Connect call failed", null, e)
+            }
+        }
+    }
 
     override fun handleOnDestroy() {
         super.handleOnDestroy()
@@ -66,8 +90,8 @@ class HealthPlugin : Plugin() {
 
         val includeHistoryAccess = call.getBoolean("requestHistoryAccess") ?: false
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             // Only request the history permission when the provider actually supports it.
             // On an older-but-supported provider it can never be granted, which would leave
             // granted.containsAll(permissions) permanently false and reopen the permission
@@ -78,15 +102,15 @@ class HealthPlugin : Plugin() {
 
             if (permissions.isEmpty()) {
                 val status = manager.authorizationStatus(client, readTypes, writeTypes, includeWorkouts, includeHistoryAccess)
-                call.resolve(status)
-                return@launch
+                resolve(status)
+                return@launchSafely
             }
 
             val granted = client.permissionController.getGrantedPermissions()
             if (granted.containsAll(permissions)) {
                 val status = manager.authorizationStatus(client, readTypes, writeTypes, includeWorkouts, includeHistoryAccess)
-                call.resolve(status)
-                return@launch
+                resolve(status)
+                return@launchSafely
             }
 
             // Store types for callback
@@ -99,11 +123,11 @@ class HealthPlugin : Plugin() {
             val intent = permissionContract.createIntent(context, permissions)
 
             try {
-                startActivityForResult(call, intent, "handlePermissionResult")
+                startActivityForResult(this, intent, "handlePermissionResult")
             } catch (e: Exception) {
                 pendingReadTypes = emptyList()
                 pendingWriteTypes = emptyList()
-                call.reject("Failed to launch Health Connect permission request.", null, e)
+                reject("Failed to launch Health Connect permission request.", null, e)
             }
         }
     }
@@ -123,10 +147,10 @@ class HealthPlugin : Plugin() {
         pendingIncludeWorkouts = false
         pendingIncludeHistoryAccess = false
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             val status = manager.authorizationStatus(client, readTypes, writeTypes, includeWorkouts, includeHistoryAccess)
-            call.resolve(status)
+            resolve(status)
         }
     }
 
@@ -148,10 +172,10 @@ class HealthPlugin : Plugin() {
 
         val includeHistoryAccess = call.getBoolean("requestHistoryAccess") ?: false
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             val status = manager.authorizationStatus(client, readTypes, writeTypes, includeWorkouts, includeHistoryAccess)
-            call.resolve(status)
+            resolve(status)
         }
     }
 
@@ -191,14 +215,14 @@ class HealthPlugin : Plugin() {
             return
         }
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             try {
                 val samples = manager.readSamples(client, dataType, startInstant, endInstant, limit, ascending)
                 val result = JSObject().apply { put("samples", samples) }
-                call.resolve(result)
+                resolve(result)
             } catch (e: Exception) {
-                call.reject(e.message ?: "Failed to read samples.", null, e)
+                reject(e.message ?: "Failed to read samples.", null, e)
             }
         }
     }
@@ -266,13 +290,13 @@ class HealthPlugin : Plugin() {
         val diastolic = call.getDouble("diastolic")
         val mindfulnessSessionType = call.getString("mindfulnessSessionType")
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             try {
                 manager.saveSample(client, dataType, value, startInstant, endInstant, metadata, systolic, diastolic, mindfulnessSessionType)
-                call.resolve()
+                resolve()
             } catch (e: Exception) {
-                call.reject(e.message ?: "Failed to save sample.", null, e)
+                reject(e.message ?: "Failed to save sample.", null, e)
             }
         }
     }
@@ -394,13 +418,13 @@ class HealthPlugin : Plugin() {
             return
         }
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             try {
                 val result = manager.queryWorkouts(client, workoutType, startInstant, endInstant, limit, ascending, anchor)
-                call.resolve(result)
+                resolve(result)
             } catch (e: Exception) {
-                call.reject(e.message ?: "Failed to query workouts.", null, e)
+                reject(e.message ?: "Failed to query workouts.", null, e)
             }
         }
     }
@@ -465,26 +489,27 @@ class HealthPlugin : Plugin() {
             return
         }
 
-        pluginScope.launch {
-            val client = getClientOrReject(call) ?: return@launch
+        call.launchSafely {
+            val client = getClientOrReject(this) ?: return@launchSafely
             try {
                 val result = manager.queryAggregated(client, dataType, startInstant, endInstant, bucket, aggregations)
-                call.resolve(result)
+                resolve(result)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: SecurityException) {
-                Log.w("HealthPlugin", "Permission denied for aggregation: ${e.message}", e)
-                call.reject(e.message ?: "Permission denied for aggregated data.", "permission-denied", e)
+                Log.w(TAG, "Permission denied for aggregation: ${e.message}", e)
+                reject(e.message ?: "Permission denied for aggregated data.", "permission-denied", e)
             } catch (e: IllegalArgumentException) {
-                call.reject(e.message ?: "Unsupported aggregation.", null, e)
+                reject(e.message ?: "Unsupported aggregation.", null, e)
             } catch (e: Exception) {
-                Log.w("HealthPlugin", "Aggregation failed: ${e.message}", e)
-                call.reject(e.message ?: "Failed to query aggregated data.", "query-aggregated-failed", e)
+                Log.w(TAG, "Aggregation failed: ${e.message}", e)
+                reject(e.message ?: "Failed to query aggregated data.", "query-aggregated-failed", e)
             }
         }
     }
 
     companion object {
+        private const val TAG = "HealthPlugin"
         private const val DEFAULT_LIMIT = 100
         private val DEFAULT_PAST_DURATION: Duration = Duration.ofDays(1)
     }

--- a/android/src/main/java/app/capgo/plugin/health/HealthPlugin.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthPlugin.kt
@@ -48,15 +48,17 @@ class HealthPlugin : Plugin() {
      * Without this, exceptions escaping a plain `launch` hit the thread's default
      * handler and kill the host app (e.g. Health Connect IPC rate limits).
      */
-    private inline fun PluginCall.launchSafely(crossinline block: suspend () -> Unit) {
+    private fun PluginCall.launchSafely(block: suspend PluginCall.() -> Unit) {
+        val call = this
         pluginScope.launch {
             try {
-                block()
+                call.block()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
                 Log.e(TAG, "Health Connect call failed", e)
-                reject(e.message ?: "Health Connect call failed", null, e)
+                val exception = e as? Exception ?: Exception(e)
+                call.reject(e.message ?: "Health Connect call failed", null, exception)
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Wrap all Android `pluginScope.launch` call sites in `PluginCall.launchSafely` so uncaught Health Connect failures reject the promise instead of crashing the app
- Add a `CoroutineExceptionHandler` on `pluginScope` as a backstop for anything that still escapes
- Sync Android `pluginVersion` from `7.2.14` to `8.10.0` (matches package / iOS)

## Why
- Uncaught exceptions in `pluginScope.launch` hit Android's default uncaught exception handler and terminate the host process
- Easy repro: Health Connect IPC rate limit (`RemoteException`) from `getGrantedPermissions` during `checkAuthorization`
- Same failure shape as previously fixed native crash issues (#38 / #81 / #55), but on Android and not data-type specific
- Fixes https://github.com/Cap-go/capacitor-health/issues/92

## How
- Added `PluginCall.launchSafely` (`suspend PluginCall.() -> Unit`) that catches non-cancellation `Throwable`, logs, converts to `Exception`, and `reject`s the call
- Kept existing per-method try/catch blocks for specific error codes/messages
- Added `CoroutineExceptionHandler` on the shared scope so a failure can never be fatal even if a call somehow escapes

## Testing
- `bun run verify:android` — BUILD SUCCESSFUL
- `bun run verify:web` — passed
- Code review of all seven former `launch` sites now using `launchSafely`

## Not Tested
- Device repro of Health Connect rate-limit crash (no Health Connect device in this environment)
- iOS verify (Linux agent has no Xcode)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe25b-d0cf-7b92-80f3-0af3e1636538?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe25b-d0cf-7b92-80f3-0af3e1636538&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-health/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788801177&installation_model_id=430928&pr_number=93&repository=Cap-go%2Fcapacitor-health&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-health%2Fpull%2F93&signature=e1bd1730d10a16e11603c6a8569c0523a20e0c2fae67686145ace8f26aad388c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-health/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

