### PR TITLE
fix(android): treat an empty pageToken as end-of-pages, not "more pages"

### DIFF
--- a/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
+++ b/android/src/main/java/app/capgo/plugin/health/HealthManager.kt
@@ -475,7 +475,16 @@ class HealthManager {
             }
             fetched += response.records.size
             pageToken = response.pageToken
-        } while (pageToken != null && (limit <= 0 || fetched < limit))
+        // On the STANDALONE Health Connect APK (Android 13 and below) an exhausted
+        // page token comes back as an EMPTY STRING, not null — see
+        // developer.android.com "Read raw data": "ReadRecordsResponse.pageToken can
+        // return an empty string instead of null ... use isNullOrEmpty()".
+        // Comparing against null alone re-issues the same readRecords forever, and
+        // Health Connect answers that by rate-limiting the app, so every read fails
+        // with "Rate limited request quota has been exceeded" — on the first call,
+        // on a device that has never been read from. Android 14+ (platform module)
+        // returns null and was never affected.
+        } while (!pageToken.isNullOrEmpty() && (limit <= 0 || fetched < limit))
     }
 
     @Suppress("UNUSED_PARAMETER")
@@ -1042,7 +1051,16 @@ private fun createSamplePayload(
             
             fetched += response.records.size
             pageToken = response.pageToken
-        } while (pageToken != null && (limit <= 0 || fetched < limit))
+        // On the STANDALONE Health Connect APK (Android 13 and below) an exhausted
+        // page token comes back as an EMPTY STRING, not null — see
+        // developer.android.com "Read raw data": "ReadRecordsResponse.pageToken can
+        // return an empty string instead of null ... use isNullOrEmpty()".
+        // Comparing against null alone re-issues the same readRecords forever, and
+        // Health Connect answers that by rate-limiting the app, so every read fails
+        // with "Rate limited request quota has been exceeded" — on the first call,
+        // on a device that has never been read from. Android 14+ (platform module)
+        // returns null and was never affected.
+        } while (!pageToken.isNullOrEmpty() && (limit <= 0 || fetched < limit))
         
         val sorted = workouts.sortedBy { it.first }
         val ordered = if (ascending) sorted else sorted.asReversed()


### PR DESCRIPTION
Both pagination loops end with

    `} while (pageToken != null && (limit <= 0 || fetched < limit))`

On the standalone Health Connect APK (Android 13 and below), ReadRecordsResponse.pageToken comes back as an EMPTY STRING rather than null when there are no further pages. "" != null is true, so the loop never terminates: the plugin re-issues the identical readRecords until Health Connect rate-limits the app.

The user-visible symptom is that every read fails with

    android.os.RemoteException: Request rejected. Rate limited request quota
    has been exceeded. Please wait until quota has replenished before making
    further requests.

on the FIRST call, on a device that has never been read from — which looks impossible, because Health Connect creates a fresh per-package quota bucket FULL and charges nothing for a rejected request. The app is exhausting its own quota in milliseconds.

Google documents the behaviour on "Read raw data": "Depending on the specific system or Health Connect APK version (such as on Android 12 and 13), ReadRecordsResponse.pageToken can return an empty string instead of null ... use isNullOrEmpty()".

Evidence (controlled A/B, one clean Android 10 emulator and a real Pixel 5 on Android 11, same Health Connect build, same androidx connect-client 1.1.0):

  Health Connect Toolbox (native)            -> read OK
  purpose-built native Kotlin app            -> read OK
  Capacitor app using this plugin            -> RATE_LIMITED on its first read

Instrumenting the loop showed one readSamples issuing many identical readRecords, the first with pageToken=null and every subsequent one with pageToken= (empty).

Ruled out as causes: read pacing, package identity, permission count, READ_HEALTH_DATA_IN_BACKGROUND, targetSdk, pageSize (100 and 500 both fail), calling context (activity vs application), coroutine dispatcher, and foreground classification (the process measured cur=TOP, and the transmitted RequestContext.isInForeground was true).

After the fix, on the same devices: one readSamples issues exactly 1 IPC and succeeds, and a six-metric sync completes with zero rejections.

Verified on Android 16 (platform module) that this is a no-op there: with and without the change the token is null, the loop exits on the first pass, 1 IPC, no rejections. So the bug is Android <= 13 only and the fix is safe on 14+.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-health/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790624132&installation_model_id=430928&pr_number=98&repository=Cap-go%2Fcapacitor-health&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-health%2Fpull%2F98&signature=bbe0a686f7669d4c128f5006c6a369b6a090f1e048bc0d0b7fe4c5e498a93588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-health/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

